### PR TITLE
FormDataEncoderTest 테스트 수행이 되지 않는 문제 해결

### DIFF
--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -294,7 +294,7 @@ class ArticleControllerTest {
 
         // When & Then
         mvc.perform(
-                        post("/articles/" + articleId)
+                        post("/articles/" + articleId + "/delete")
                                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                                 .with(csrf())
                 )

--- a/src/test/java/com/fastcampus/projectboard/util/FormDataEncoder.java
+++ b/src/test/java/com/fastcampus/projectboard/util/FormDataEncoder.java
@@ -1,6 +1,5 @@
 package com.fastcampus.projectboard.util;
 
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.test.context.TestComponent;
@@ -19,6 +18,7 @@ public class FormDataEncoder {
         this.mapper = mapper;
     }
 
+
     public String encode(Object obj) {
         Map<String, String> fieldMap = mapper.convertValue(obj, new TypeReference<>() {});
         MultiValueMap<String, String> valueMap = new LinkedMultiValueMap<>();
@@ -30,4 +30,5 @@ public class FormDataEncoder {
                 .build()
                 .getQuery();
     }
+
 }

--- a/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
+++ b/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
@@ -5,16 +5,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.context.annotation.Import;
 
 import java.math.BigDecimal;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("테스트 도구 - Form 데이터 인코더")
 @Import({FormDataEncoder.class, ObjectMapper.class})
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = Void.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = FormDataEncoderTest.EmptyConfig.class)
 class FormDataEncoderTest {
 
     private final FormDataEncoder formDataEncoder;
@@ -28,7 +29,7 @@ class FormDataEncoderTest {
     void givenObject_whenEncoding_thenReturnsFormEncodedString() {
         // Given
         TestObject obj = new TestObject(
-                "This 'is' \"TEST\" string.",
+                "This 'is' \"test\" string.",
                 List.of("hello", "my", "friend").toString().replace(" ", ""),
                 String.join(",", "hello", "my", "friend"),
                 null,
@@ -71,4 +72,7 @@ class FormDataEncoderTest {
     enum TestEnum {
         ONE, TWO, THREE
     }
+
+    @TestComponent
+    public static class EmptyConfig {}
 }


### PR DESCRIPTION
`@SpringBootTest`의 `classes` 엘리먼트로 `Void.class`를 넣었기 때문에 테스트 수행 시 에러가 발생함 정확한 사용법을 준수하려면 이 안에는 아무 클래스나 넣어서는 안되므로, 제대로 한다면 빈을 하나 만들어서 넣어야 하기에 `EmptyConfig` 의 이너 클래스를 작성하여 `classes`에 넣어줌
테스트 수행하고 문제없음을 확인

`ArticleControllerTest`의 삭제 테스트 부분에 빠진 uri 추가

This closes #42